### PR TITLE
add event keyboard clicks CTRL + ENTER to run challenge tests

### DIFF
--- a/src/components/Challenges/CodeChallenge/CodeChallenge.tsx
+++ b/src/components/Challenges/CodeChallenge/CodeChallenge.tsx
@@ -47,15 +47,13 @@ export const CodeChallenge = ({
   useEffect(resetChallenge, [id]);
 
   // passes test when control & enter keys are pressed together
-  useEffect(() => {
-    window.addEventListener('keydown', (e: KeyboardEvent) => {
-      e.preventDefault();
-      if (e.ctrlKey && e.code === "Enter") {
-        runTests();
-      }
+  const passTestsOnKeypress = () => {
+    window.addEventListener('keypress', (e:KeyboardEvent) => {
+      ((e.ctrlKey || e.metaKey) && e.code === "Enter") ? runTests() : null;
     })
-  }, []);
-
+  }
+  
+  useEffect(passTestsOnKeypress,[]);
 
   return (
     <>
@@ -104,9 +102,6 @@ interface ITestsProps {
 
 const Tests = ({ tests }: ITestsProps) => {
   const { testResults } = useCodeChallengeTests(tests);
-
-
-
 
   return (
     <Box>

--- a/src/components/Challenges/CodeChallenge/CodeChallenge.tsx
+++ b/src/components/Challenges/CodeChallenge/CodeChallenge.tsx
@@ -46,6 +46,17 @@ export const CodeChallenge = ({
 
   useEffect(resetChallenge, [id]);
 
+  // passes test when control & enter keys are pressed together
+  useEffect(() => {
+    window.addEventListener('keydown', (e: KeyboardEvent) => {
+      e.preventDefault();
+      if (e.ctrlKey && e.code === "Enter") {
+        runTests();
+      }
+    })
+  }, []);
+
+
   return (
     <>
       <Box mt="15px" />
@@ -94,6 +105,9 @@ interface ITestsProps {
 const Tests = ({ tests }: ITestsProps) => {
   const { testResults } = useCodeChallengeTests(tests);
 
+
+
+
   return (
     <Box>
       <Heading size="md" mr="auto" my="23px">
@@ -111,3 +125,5 @@ const Tests = ({ tests }: ITestsProps) => {
     </Box>
   );
 };
+
+

--- a/src/components/Challenges/CodeChallenge/CodeChallenge.tsx
+++ b/src/components/Challenges/CodeChallenge/CodeChallenge.tsx
@@ -57,8 +57,7 @@ export const CodeChallenge = ({
     window.addEventListener('keypress', handleUserKeyPress);
     return () => {
       window.removeEventListener('keypress', handleUserKeyPress);
-    }
-  }, [])
+    }}, []);
 
 
   return (

--- a/src/components/Challenges/CodeChallenge/CodeChallenge.tsx
+++ b/src/components/Challenges/CodeChallenge/CodeChallenge.tsx
@@ -47,13 +47,19 @@ export const CodeChallenge = ({
   useEffect(resetChallenge, [id]);
 
   // passes test when control & enter keys are pressed together
-  const passTestsOnKeypress = () => {
-    window.addEventListener('keypress', (e:KeyboardEvent) => {
-      ((e.ctrlKey || e.metaKey) && e.code === "Enter") ? runTests() : null;
-    })
+  const handleUserKeyPress = (e: KeyboardEvent) => {
+    if (((e.ctrlKey || e.metaKey) && e.code === "Enter")) {
+      runTests();
+    }
   }
-  
-  useEffect(passTestsOnKeypress,[]);
+
+  useEffect(() => {
+    window.addEventListener('keypress', handleUserKeyPress);
+    return () => {
+      window.removeEventListener('keypress', handleUserKeyPress);
+    }
+  }, [])
+
 
   return (
     <>

--- a/src/components/ContentPanel/ContentPanel.tsx
+++ b/src/components/ContentPanel/ContentPanel.tsx
@@ -33,6 +33,7 @@ export const ContentPanel = memo(
       );
     }, []);
 
+    
     return (
       <Box
         bgColor="white"


### PR DESCRIPTION
Added keyboard event listeners to listen for keyboard clicks of CTRL + ENTER to run challenge tests. This works on windows, but I'm not sure how it would work on MacOS.